### PR TITLE
Refactor index styles to remove duplicates

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,87 +12,126 @@
             line-height: 1.5;
             margin: 0;
             padding: 0;
+            background-color: #f8f8f8;
         }
 
-        /* Anchor links styling */
         a {
             color: #D27A22;
             text-decoration: none;
         }
 
         a:hover {
-            text-decoration: underline;
             color: #FF9900;
+            text-decoration: underline;
         }
 
-        /* Unordered list styling */
         ul {
-            list-style-type: disc;
-            margin-left: 20px;
+            list-style: disc;
+            margin: 0 0 10px 20px;
+            padding: 0;
         }
 
         ul li {
             margin-bottom: 10px;
         }
 
-        /* Image box-shadow for profile picture */
         .image-placeholder img {
             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
         }
 
-        /* Container for main content */
         .container {
             width: 900px;
             margin: 20px auto;
+            padding: 20px;
             display: flex;
             justify-content: space-between;
             background-color: #fff;
             box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
         }
 
-        /* Left Sidebar */
         .sidebar {
             width: 30%;
             background-color: #355070;
             padding: 20px;
-            color: white;
+            color: #fff;
         }
 
-        /* Sidebar Headers */
         .sidebar h2 {
-            color: #fff;
             font-size: 18px;
             margin-bottom: 15px;
             text-transform: uppercase;
         }
 
-        /* General Sidebar Paragraph Styling */
         .sidebar p {
             margin-bottom: 10px;
         }
 
-        /* Sidebar Section Styling */
         .sidebar-section {
             margin-bottom: 30px;
+        }
+
+        .sidebar-section span,
+        .sidebar-section p {
+            display: flex;
+            align-items: center;
         }
 
         .sidebar-section p {
             margin: 5px 0;
         }
 
-        /* Personal Details Icons */
-        .icon {
+        .sidebar-section i {
             margin-right: 10px;
+            font-size: 18px;
+        }
+
+        .sidebar-section a {
+            display: inline-block;
+            margin-bottom: 10px;
+            color: #fff;
+            text-decoration: none;
+        }
+
+        .sidebar-section a:hover {
+            color: #ddd;
+            text-decoration: underline;
+        }
+
+        .sidebar-section a i {
+            margin-right: 15px;
+        }
+
+        .stars {
+            display: inline-block;
+            color: #000;
             font-size: 16px;
         }
 
-        /* Main Content Area */
-        .main-content {
-            width: 70%;
-            padding: 20px;
+        .skills ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
         }
 
-        /* Main Content Headings */
+        .skills ul li {
+            position: relative;
+            padding-left: 15px;
+            margin-bottom: 8px;
+        }
+
+        .skills ul li::before {
+            content: '•';
+            position: absolute;
+            left: 0;
+            top: 0;
+            color: #D27A22;
+        }
+
+        .main-content {
+            width: 70%;
+            padding: 20px 20px 20px 30px;
+        }
+
         .main-content h1 {
             font-size: 36px;
             color: #D27A22;
@@ -100,163 +139,68 @@
 
         .main-content h2 {
             font-size: 18px;
-            color: #ffffff;
             background-color: #355070;
+            color: #ffffff;
             padding: 5px 10px;
             text-transform: uppercase;
             margin-bottom: 15px;
         }
 
-        /* Work Experience and Education Styling */
         .main-content h3 {
-            background-color: #f0f0f0;
-            padding: 5px;
-            font-weight: bold;
-            color: #333;
             margin-top: 10px;
+            padding: 5px 5px 5px 9px;
+            background-color: #f0f0f0;
             border-left: 4px solid #D27A22;
+            color: #333;
+            font-weight: bold;
         }
 
-        /* General Paragraph Styling */
-        .main-content p {
+        .main-content p,
+        .main-content ul {
             margin-bottom: 10px;
-        }
-
-        /* Section Margins */
-        .work-experience,
-        .education,
-        .skills,
-        .projects {
-            margin-bottom: 20px;
         }
 
         .main-content ul {
-            margin-left: 20px;
+            padding-left: 10px;
         }
 
-        /* Language section with stars */
-        .stars {
-            display: inline-block;
+        .work-experience,
+        .education,
+        .projects,
+        .previous-experience {
+            margin-bottom: 20px;
         }
 
-        .stars span {
-            color: #000;
-            font-size: 16px;
-        }
-
-        /* Footer styles */
-        .footer {
-            font-size: 12px;
-            color: #555;
-            margin-top: 20px;
-        }
-
-        /* Skills and Experience sections with square bullet points */
-        .skills ul,
         .previous-experience ul {
-            list-style-type: square;
-            margin-left: 20px;
-        }
-
-        /* Sidebar Icons and Links */
-        .sidebar-section a i {
-            font-size: 18px;
-            margin-right: 15px;
-        }
-
-        /* Sidebar Links and Spacing */
-        .sidebar-section a {
-            display: inline-block;
-            margin-bottom: 10px;
-            color: white;
-            text-decoration: none;
-        }
-
-        /* Flexbox for Aligning Icons and Text */
-        .sidebar-section p {
-            display: flex;
-            align-items: center;
-            margin-bottom: 10px;
-        }
-
-        /* Sidebar Icon Sizing */
-        .sidebar-section i {
-            margin-right: 10px;
-            font-size: 18px;
-        }
-
-        /* Sidebar Hover Effect */
-        .sidebar-section p a:hover {
-            color: #ddd;
-        }
-
-        /* Flexbox for Icon Alignment */
-        .sidebar-section span {
-            display: flex;
-            align-items: center;
-        }
-
-        /* Projects Section */
-        .projects h3 {
-            font-size: 14px;
-            /* Smaller font size for project titles */
-            color: #333;
-            margin-top: 5px;
-            /* Reduced margin */
-            margin-bottom: 5px;
-            font-weight: bold;
-        }
-
-        .projects p {
-            font-size: 12px;
-            /* Smaller font size for descriptions */
-            margin-bottom: 5px;
-            /* Reduced space between paragraphs */
-            color: #555;
-        }
-
-        .projects ul {
-            margin-left: 15px;
-            /* Smaller left margin */
-            margin-bottom: 5px;
-            /* Less space between list items */
-        }
-
-        .projects li {
-            font-size: 12px;
-            /* Smaller font size for list items */
-            margin-bottom: 3px;
-            /* Reduced space between list items */
+            list-style: square;
         }
 
         .projects {
             margin-bottom: 15px;
-            /* Reduced bottom margin */
         }
 
-        /* Projects Section */
         .projects h3 {
-            font-size: 12px;
-            /* Smaller font size for project titles */
-            color: #333;
-            margin-top: 5px;
-            margin-bottom: 5px;
-            font-weight: bold;
             display: inline;
-            /* Display title and description inline */
+            font-size: 12px;
+            font-weight: bold;
+            margin: 5px 0;
+            color: #333;
         }
 
         .projects span.description {
             font-size: 12px;
-            /* Smaller font for descriptions */
             color: #777;
-            /* Lighter color for description */
             margin-left: 10px;
-            /* Space between title and description */
+        }
+
+        .projects p {
+            font-size: 12px;
+            margin-bottom: 5px;
+            color: #555;
         }
 
         .projects ul {
-            margin: 0;
+            margin: 5px 0 5px 15px;
         }
 
         .projects li {
@@ -264,144 +208,41 @@
             margin-bottom: 3px;
         }
 
-        /* Sidebar Skills Section */
-        .skills ul {
-            list-style-type: none;
-            /* Remove default list style */
-            padding-left: 0;
-            /* Remove left padding */
-            padding-top: 0;
-        }
-
-        .skills ul li {
-            margin-left: 0;
-            /* Remove left margin */
-            padding-left: 10px;
-            /* Add some padding to align neatly */
-            text-indent: -10px;
-            /* Adjust the text indent for better alignment */
-            position: relative;
-        }
-
-        .skills ul li:before {
-            content: "•";
-            /* Use bullet point */
-            color: #D27A22;
-            /* Change bullet point color */
-            position: absolute;
-            left: 0;
-            /* Align bullet point closer to the text */
-            top: 0;
-        }
-
         .project-link {
             font-size: 12px;
-            /* Make the project link smaller */
             margin-bottom: 10px;
         }
 
         .project-link a {
             color: #D27A22;
-            text-decoration: none;
         }
 
         .project-link a:hover {
             text-decoration: underline;
         }
 
-
-
-
-
-        /* Styles specific for print */
-        @media print {
-            body {
-                margin: 0;
-                padding: 0;
-                background-color: white;
-            }
-
-            .container {
-                width: 100%;
-                margin: 0;
-                padding: 0;
-                box-shadow: none;
-            }
-
-            /* Force background colors and keep color styles */
-            * {
-                -webkit-print-color-adjust: exact;
-                /* For Chrome/Safari */
-                color-adjust: exact;
-                /* For Firefox */
-            }
-
-            /* Make only the container visible for printing */
-            body * {
-                visibility: hidden;
-            }
-
-            .container,
-            .container * {
-                visibility: visible;
-            }
-
-            /* Disable margins around the content */
-            .container {
-                position: absolute;
-                top: 0;
-                left: 0;
-                right: 0;
-                bottom: 0;
-                margin: 0;
-                padding: 0;
-            }
+        .description {
+            font-size: 12px;
+            color: #555;
         }
 
-        /* Sidebar and other element colors */
-        .sidebar {
-            background-color: #355070;
-            /* Keep sidebar color for print */
-            color: white;
-        }
-
-        .main-content h1,
-        .main-content h2,
-        .main-content h3 {
+        .inline-link {
             color: #D27A22;
         }
 
-        .main-content h2 {
-            background-color: #355070;
-            /* Ensure h2 background stays visible */
-            color: #ffffff;
+        .inline-link:hover {
+            text-decoration: underline;
         }
 
+        .footer {
+            font-size: 12px;
+            color: #555;
+            margin-top: 20px;
+        }
 
-
-        /* General styles for normal screen display */
-        @media screen {
+        @media print {
             body {
-                margin: 0;
-                padding: 0;
-                background-color: #f8f8f8;
-            }
-
-            .container {
-                width: 900px;
-                margin: 20px auto;
-                padding: 20px;
                 background-color: #fff;
-                box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
-            }
-        }
-
-        /* Styles specific for print */
-        @media print {
-            body {
-                margin: 0;
-                padding: 0;
-                background-color: white;
             }
 
             .container {
@@ -409,17 +250,18 @@
                 margin: 0;
                 padding: 0;
                 box-shadow: none;
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
             }
 
-            /* Force background colors and keep color styles */
             * {
                 -webkit-print-color-adjust: exact;
-                /* For Chrome/Safari */
                 color-adjust: exact;
-                /* For Firefox */
             }
 
-            /* Make only the container visible for printing */
             body * {
                 visibility: hidden;
             }
@@ -428,68 +270,9 @@
             .container * {
                 visibility: visible;
             }
-
-            /* Disable margins around the content */
-            .container {
-                position: absolute;
-                top: 0;
-                left: 0;
-                right: 0;
-                bottom: 0;
-                margin: 0;
-                padding: 0;
-            }
-        }
-
-        /* Sidebar and other element colors */
-        .sidebar {
-            background-color: #355070;
-            /* Keep sidebar color for print */
-            color: white;
-        }
-
-        .main-content h1,
-        .main-content h2,
-        .main-content h3 {
-            color: #D27A22;
-        }
-
-        .main-content h2 {
-            background-color: #355070;
-            /* Ensure h2 background stays visible */
-            color: #ffffff;
-        }
-
-        /* Adjust main content padding for alignment */
-        .main-content {
-            padding-left: 30px;
-            /* Adjust this padding to center content better */
-        }
-
-        /* Work experience adjustments */
-        .work-experience h3,
-        .work-experience p,
-        .work-experience ul {
-            padding-left: 10px;
-            /* Adjust this padding to bring it to the right */
-            margin-left: 0;
-            /* Reset margin to avoid extra left shift */
-        }
-
-        /* Skills adjustments to reduce spacing */
-        .skills ul li {
-            padding-left: 10px;
-            /* Slightly move to the right */
-            margin-left: 0;
-            /* Reset to align properly */
-        }
-
-        /* Ensure consistent padding inside main content */
-        .main-content p,
-        .main-content ul {
-            padding-left: 10px;
         }
     </style>
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 
 </head>
@@ -741,25 +524,6 @@
                         Index Group.</li>
                 </ul>
             </div>
-
-            <style>
-                .description {
-                    font-size: 12px;
-                    /* Make the description smaller */
-                    color: #555;
-                    /* Grayish color for the description */
-                }
-
-                .inline-link {
-                    color: #D27A22;
-                    text-decoration: none;
-                }
-
-                .inline-link:hover {
-                    text-decoration: underline;
-                }
-            </style>
-
 
             <div class="projects">
                 <h2>Projects</h2>


### PR DESCRIPTION
## Summary
- consolidate the inline CSS in `index.html` to remove duplicate rules and align shared styling across sections
- streamline print-specific rules and drop redundant inline style blocks for project descriptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d03f631f0c83329e6bd2a576b64453